### PR TITLE
Add solution for q3. subsets issue #59

### DIFF
--- a/Bit Manipulation/Subsets/tejasvi230--Q3. Subsets.cpp
+++ b/Bit Manipulation/Subsets/tejasvi230--Q3. Subsets.cpp
@@ -1,0 +1,34 @@
+#include <bits/stdc++.h>
+using namespace std;
+
+int main() {
+    ios::sync_with_stdio(false);
+    cin.tie(nullptr);
+
+    int n;
+    cin >> n;
+
+    vector<int> a(n);
+    for (int i = 0; i < n; i++) cin >> a[i];
+
+    int total = 1 << n;   // total subsets = 2^n
+
+    // iterate over all bitmasks
+    for (int mask = 0; mask < total; mask++) {
+        cout << "[";
+
+        bool first = true;
+        for (int i = 0; i < n; i++) {
+            // if i-th bit is set, include a[i]
+            if (mask & (1 << i)) {
+                if (!first) cout << ",";
+                cout << a[i];
+                first = false;
+            }
+        }
+
+        cout << "]\n";
+    }
+
+    return 0;
+}


### PR DESCRIPTION
Approach
Used bitmasking to generate subsets.

For an array of size n, there are 2^n possible subsets.
Each number from 0 to 2^n - 1 is treated as a bitmask where the i-th bit decides whether the i-th element is included in the current subset.

Implementation Details

Iterate over all bitmasks
Check each bit using bitwise AND
Include corresponding element if the bit is set
Avoid recursion for better performance

Complexity
Time Complexity: O(n × 2^n)
Space Complexity: O(1) (excluding output)